### PR TITLE
fixed spelling of "Residential" from "Resedential"

### DIFF
--- a/app/assets/javascripts/bartotals.js
+++ b/app/assets/javascripts/bartotals.js
@@ -18,7 +18,7 @@ var datagasbar = {
             data: [comgas],
         },
         {
-            label: "Resedential",
+            label: "Residential",
             backgroundColor: "rgba(130,220,170,0.6)",
             borderColor: "rgba(130,220,170,1)",
             borderWidth: 1,
@@ -66,7 +66,7 @@ var dataelectricbar = {
             data: [comelectric],
         },
         {
-            label: "Resedential",
+            label: "Residential",
             backgroundColor: "rgba(130,220,170,0.6)",
             borderColor: "rgba(130,220,170,1)",
             borderWidth: 1,


### PR DESCRIPTION
When I visited http://greengraph.org today, I noticed a typo in the spelling of "Residential" on the bar graphs. This change fixes the spelling.
